### PR TITLE
 Fix where plugin failed under ns7

### DIFF
--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -157,6 +157,9 @@ if (!global.sessionStorage) {
 }
 
 
+export default global.localStorage;
+
+
 if (module.hot) {
     module.hot.accept();
     module.hot.dispose(() => {

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -7,7 +7,7 @@
 'use strict';
 
 
-let FileSystemAccess = require('tns-core-modules/file-system/file-system-access').FileSystemAccess;
+import {FileSystemAccess} from "@nativescript/core/file-system/file-system-access";
 
 // So that code that is looking for the "Storage" object will pass its check
 if (!global.Storage) {
@@ -156,10 +156,6 @@ if (!global.sessionStorage) {
     });
 }
 
-
-
-
-module.exports = global.localStorage;
 
 if (module.hot) {
     module.hot.accept();


### PR DESCRIPTION
This plugin stopped working with ns7.

* I changed the require to the new `@nativescript/core` import.
* I had to remove `module.exports = global.localStorage;` as otherwise I would get this error:

`TypeError: Cannot assign to read only property 'exports' of object '#<Object>'`

I then later replaced it with `export default global.localStorage;`. I'm not sure how this will effect things but the plugin appears to be working now.